### PR TITLE
Fix exception for use completion when a edit group is already started.

### DIFF
--- a/PSReadLine/PublicAPI.cs
+++ b/PSReadLine/PublicAPI.cs
@@ -102,7 +102,10 @@ namespace Microsoft.PowerShell
                 throw new ArgumentException(PSReadLineResources.ReplacementLengthTooBig, "length");
             }
 
-            _singleton.StartEditGroup();
+            bool useEditGroup = (_singleton._editGroupStart == -1);
+
+            if(useEditGroup)
+                _singleton.StartEditGroup();
             var str = _singleton._buffer.ToString(start, length);
             _singleton.SaveEditItem(EditItemDelete.Create(str, start));
             _singleton._buffer.Remove(start, length);
@@ -116,7 +119,8 @@ namespace Microsoft.PowerShell
             {
                 _singleton._current = start;
             }
-            _singleton.EndEditGroup(instigator, instigatorArg); // Instigator is needed for VI undo
+            if(useEditGroup)
+                _singleton.EndEditGroup(instigator, instigatorArg); // Instigator is needed for VI undo
             _singleton.Render();
         }
 


### PR DESCRIPTION
When trying to use Complete command, and there's already a started edit group, a InvalidException is thrown.

This can be simulated using command C, and inside C editing trying to use Complete.

The C command starts a Edit Group, but will only end it when editing is done. So, using Complete command in this context will cause an Exception.
